### PR TITLE
Add AppVeyor Windows CI to tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [Installation](http://rclone.org/install/) |
 [G+](https://google.com/+RcloneOrg)
 
-[![Build Status](https://travis-ci.org/ncw/rclone.png?branch=master)](https://travis-ci.org/ncw/rclone) [![GoDoc](https://godoc.org/github.com/ncw/rclone?status.svg)](https://godoc.org/github.com/ncw/rclone)
+
+[![Build Status](https://travis-ci.org/ncw/rclone.png?branch=master)](https://travis-ci.org/ncw/rclone) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/ncw/rclone?branch=master&passingText=windows%20-%20ok&svg=true)](https://ci.appveyor.com/project/ncw/rclone) [![GoDoc](https://godoc.org/github.com/ncw/rclone?status.svg)](https://godoc.org/github.com/ncw/rclone) 
 
 Rclone is a command line program to sync files and directories to and from
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+clone_folder: c:\gopath\src\github.com\ncw\rclone
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - go get golang.org/x/tools/cmd/vet
+  - echo %PATH%
+  - echo %GOPATH%
+  - go version
+  - go env
+  - go get -d ./...
+
+build_script:
+ - go vet ./...
+ - go test -v -cpu=2 ./...
+ - go test -cpu=2 -short -race ./...


### PR DESCRIPTION
AppVeyor is free, and functions pretty much like Travis, only on Windows.

I am a bit uncertain about the image URL, since I obviously cannot test it.
